### PR TITLE
fix: Dll Paths were not properly sanitised

### DIFF
--- a/inject-lib/Cargo.toml
+++ b/inject-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "inject-lib"
-version = "0.3.1"
+version = "0.3.2"
 description = "A windows dll injection library written in rust with minimal dependencies."
 readme = "README.md"
 repository = "https://github.com/C0D3-M4513R/inject-lib"


### PR DESCRIPTION
In dll Paths from crate::platform::windows::get_module the "System32"
and "SysWOW64" part of dll paths were not properly handled before it was
passed to crate::platform::windows::get_dll_export.

Closes #34